### PR TITLE
Dynamic value  for textarea

### DIFF
--- a/projects/common-form-elements/src/lib/dynamic-textarea/dynamic-textarea.component.html
+++ b/projects/common-form-elements/src/lib/dynamic-textarea/dynamic-textarea.component.html
@@ -1,6 +1,6 @@
 <div class="sb-textarea-container">
   <label [attr.data-title]="field.description ? field.description : null">{{label}}</label>
-  <textarea class="sb-textarea" [formControl]="formControlRef" rows="5" name="sb-textarea" placeholder={{placeholder}} [attr.disabled]="disabled ? true : null">
+  <textarea class="sb-textarea" [formControl]="formControlRef" rows="5" name="sb-textarea" placeholder={{placeholder}} [attr.disabled]="disabled ? true : null" maxlength="maxLengthVal">
   </textarea>
   <div class="remaining-length" *ngIf="remainderValidLength$">
      {{remainderValidLength$ | async}} Characters left

--- a/projects/common-form-elements/src/lib/dynamic-textarea/dynamic-textarea.component.ts
+++ b/projects/common-form-elements/src/lib/dynamic-textarea/dynamic-textarea.component.ts
@@ -20,6 +20,7 @@ export class DynamicTextareaComponent implements OnInit {
   @Input() disabled: Boolean;
 
   remainderValidLength$?: Observable<number>;
+  maxLengthVal = 0;
 
   constructor() {
   }
@@ -28,6 +29,7 @@ export class DynamicTextareaComponent implements OnInit {
     const maxLengthValidation = this.field.validations &&
     this.field.validations.find((validation) => validation.type === FieldConfigValidationType.MAXLENGTH);
 
+    this.maxLengthVal = maxLengthValidation.value as number;
     if (maxLengthValidation) {
       this.remainderValidLength$ = this.formControlRef.valueChanges.pipe(
         startWith(''),


### PR DESCRIPTION
Copy content metadata from one framework to another and it varies in form config like maxLength, 
- XYZ framework form config is having a description field max length is 512.
- ABC framework form config is having a description field max length is 256.

In the above 2 frameworks, content copy from XYZ framework to ABC framework, but there is a mismatch in form description field value, so it should not allow the max character based on maxLength value. 

So this fix will make sure its own max length and restrict irrespective of the incoming value.